### PR TITLE
allow credentials to be overridden using env variables

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,3 +353,9 @@ db {
 }
 
 include "credentials.conf"
+
+aws {
+  accessKeyId = ${?AWS_KEY}
+  secretAccessKey = ${?AWS_SECRET}
+  region = ${?AWS_REGION}
+}


### PR DESCRIPTION
- if there is an env variables set for aws credentials, override what is in `credentials.conf`